### PR TITLE
Update project tt_um_urish_ringosc_cnt (TinyTapeout/tt05-ringosc-counter)

### DIFF
--- a/projects/tt_um_urish_ringosc_cnt/commit_id.json
+++ b/projects/tt_um_urish_ringosc_cnt/commit_id.json
@@ -3,6 +3,7 @@
   "repo": "https://github.com/TinyTapeout/tt05-ringosc-counter",
   "commit": "3717208f1e457b03587a497a6453cd541a4916a2",
   "workflow_url": "https://github.com/TinyTapeout/tt05-ringosc-counter/actions/runs/6615590239",
-  "sort_id": 1697375363031,
-  "openlane_version": "OpenLane2 2.0.0b15"
+  "sort_id": 1698484894486,
+  "openlane_version": "OpenLane2 2.0.0b15",
+  "power_gate": true
 }


### PR DESCRIPTION
Update project tt_um_urish_ringosc_cnt to commit TinyTapeout/tt05-ringosc-counter@3717208f1e457b03587a497a6453cd541a4916a2

Workflow: https://github.com/TinyTapeout/tt05-ringosc-counter/actions/runs/6615590239
