### PR TITLE
Update project tt_um_seven_segment_seconds (TinyTapeout/tt04-verilog-demo)

### DIFF
--- a/projects/tt_um_seven_segment_seconds/commit_id.json
+++ b/projects/tt_um_seven_segment_seconds/commit_id.json
@@ -3,6 +3,7 @@
   "repo": "https://github.com/TinyTapeout/tt04-verilog-demo",
   "commit": "616b178830f59d7fec3c077146916cd95ad79596",
   "workflow_url": "https://github.com/TinyTapeout/tt04-verilog-demo/actions/runs/6518482310",
-  "sort_id": 1697297367815,
-  "openlane_version": "OpenLane 7e5a2e9fb274c0a100b4859a927adce7089455ff\n"
+  "sort_id": 1698485300689,
+  "openlane_version": "OpenLane 7e5a2e9fb274c0a100b4859a927adce7089455ff\n",
+  "power_gate": false
 }


### PR DESCRIPTION
Update project tt_um_seven_segment_seconds to commit TinyTapeout/tt04-verilog-demo@616b178830f59d7fec3c077146916cd95ad79596

Workflow: https://github.com/TinyTapeout/tt04-verilog-demo/actions/runs/6518482310
